### PR TITLE
Support `omitempty` option on JSON marshaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,28 @@ if err != nil {
 // unmarshalJSONStruct.Val == None[int]()
 ```
 
+And this also supports `omitempty` option for JSON unmarshaling. If the value of the property is `None[T]` and that property has `omitempty` option, it omits that property.
+
+ref:
+
+> The "omitempty" option specifies that the field should be omitted from the encoding if the field has an empty value, defined as false, 0, a nil pointer, a nil interface value, and any empty array, slice, map, or string.
+> https://pkg.go.dev/encoding/json#Marshal
+
+example:
+
+```go
+type JSONStruct struct {
+	OmitemptyVal Option[string] `json:"omitemptyVal,omitempty"` // this should be omitted
+}
+
+jsonStruct := &JSONStruct{OmitemptyVal: None[string]()}
+marshal, err := json.Marshal(jsonStruct)
+if err != nil {
+	return err
+}
+fmt.Printf("%s\n", marshal) // => {}
+```
+
 ## Tips
 
 - it would be better to deal with an Option value as a non-pointer because if the Option value can accept nil it becomes worthless

--- a/option_test.go
+++ b/option_test.go
@@ -62,7 +62,7 @@ func TestOption_Filter(t *testing.T) {
 
 	o := Some[int](2).Filter(isEven)
 	assert.True(t, o.IsSome())
-	assert.Equal(t, 2, o.value)
+	assert.Equal(t, 2, o[value])
 
 	o = Some[int](1).Filter(isEven)
 	assert.True(t, o.IsNone())
@@ -111,7 +111,7 @@ func TestZip(t *testing.T) {
 	assert.Equal(t, Pair[int, string]{
 		Value1: 123,
 		Value2: "foo",
-	}, zipped.value)
+	}, zipped[value])
 
 	assert.True(t, Zip(none, some1).IsNone())
 	assert.True(t, Zip(some1, none).IsNone())
@@ -136,7 +136,7 @@ func TestZipWith(t *testing.T) {
 	assert.Equal(t, Data{
 		A: "foo",
 		B: 123,
-	}, zipped.value)
+	}, zipped[value])
 
 	assert.True(t, ZipWith(None[int](), some1, func(v1, v2 int) Data {
 		return Data{}
@@ -519,4 +519,17 @@ func TestOption_UnmarshalJSON_shouldReturnErrorWhenInvalidJSONStringInputHasCome
 	var unmarshalJSONStruct JSONStruct
 	err := json.Unmarshal([]byte(`{"val":"__STRING__"}`), &unmarshalJSONStruct)
 	assert.Error(t, err)
+}
+
+func TestOption_MarshalJSON_shouldHandleOmitemptyCorrectly(t *testing.T) {
+	type JSONStruct struct {
+		NormalVal    Option[string] `json:"normalVal"`
+		OmitemptyVal Option[string] `json:"omitemptyVal,omitempty"` // this should be omitted
+	}
+
+	none := None[string]()
+	jsonStruct := &JSONStruct{NormalVal: none, OmitemptyVal: none}
+	marshal, err := json.Marshal(jsonStruct)
+	assert.NoError(t, err)
+	assert.EqualValues(t, string(marshal), `{"normalVal":null}`)
 }


### PR DESCRIPTION
This pull request makes it support the `omitempty` option on JSON marshaling. If the property has that option and the value is `None[T]`, it omits that property from serialized JSON string.

example:

```go
type JSONStruct struct {
	OmitemptyVal Option[string] `json:"omitemptyVal,omitempty"` // this should be omitted
}
jsonStruct := &JSONStruct{OmitemptyVal: None[string]()}
marshal, err := json.Marshal(jsonStruct)
if err != nil {
	return err
}
fmt.Printf("%s\n", marshal) // => {}
```