### PR TITLE
feat: add `OrElse()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ and more detailed examples are here: [./examples_test.go](./examples_test.go).
 - [Option[T]#TakeOr(fallbackValue T) T](https://pkg.go.dev/github.com/moznion/go-optional#Option.TakeOr)
 - [Option[T]#TakeOrElse(fallbackFunc func() T) T](https://pkg.go.dev/github.com/moznion/go-optional#Option.TakeOrElse)
 - [Option[T]#Or(fallbackOptionValue Option[T]) Option[T]](https://pkg.go.dev/github.com/moznion/go-optional#Option.Or)
+- [Option[T]#OrElse(fallbackOptionFunc func() Option[T]) Option[T]](https://pkg.go.dev/github.com/moznion/go-optional#Option.OrElse)
 - [Option[T]#Filter(predicate func(v T) bool) Option[T]](https://pkg.go.dev/github.com/moznion/go-optional#Option.Filter)
 - [Option[T]#IfSome(f func(v T))](https://pkg.go.dev/github.com/moznion/go-optional#Option.IfSome)
 - [Option[T]#IfSomeWithError(f func(v T) error) error](https://pkg.go.dev/github.com/moznion/go-optional#Option.IfSomeWithError)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ and more detailed examples are here: [./examples_test.go](./examples_test.go).
 - [Option[T]#Take() (T, error)](https://pkg.go.dev/github.com/moznion/go-optional#Option.Take)
 - [Option[T]#TakeOr(fallbackValue T) T](https://pkg.go.dev/github.com/moznion/go-optional#Option.TakeOr)
 - [Option[T]#TakeOrElse(fallbackFunc func() T) T](https://pkg.go.dev/github.com/moznion/go-optional#Option.TakeOrElse)
-- [Option[T]#OrElse(fallbackOptionValue Option[T]) Option[T]](https://pkg.go.dev/github.com/moznion/go-optional#Option.OrElse)
+- [Option[T]#Or(fallbackOptionValue Option[T]) Option[T]](https://pkg.go.dev/github.com/moznion/go-optional#Option.Or)
 - [Option[T]#Filter(predicate func(v T) bool) Option[T]](https://pkg.go.dev/github.com/moznion/go-optional#Option.Filter)
 - [Option[T]#IfSome(f func(v T))](https://pkg.go.dev/github.com/moznion/go-optional#Option.IfSome)
 - [Option[T]#IfSomeWithError(f func(v T) error) error](https://pkg.go.dev/github.com/moznion/go-optional#Option.IfSomeWithError)

--- a/examples_test.go
+++ b/examples_test.go
@@ -564,3 +564,17 @@ func ExampleOption_Or() {
 	// Some[actual]
 	// Some[fallback]
 }
+
+func ExampleOption_OrElse() {
+	fallbackFunc := func() Option[string] { return Some[string]("fallback") }
+
+	some := Some[string]("actual")
+	fmt.Printf("%s\n", some.OrElse(fallbackFunc))
+
+	none := None[string]()
+	fmt.Printf("%s\n", none.OrElse(fallbackFunc))
+
+	// Output:
+	// Some[actual]
+	// Some[fallback]
+}

--- a/examples_test.go
+++ b/examples_test.go
@@ -551,14 +551,14 @@ func ExampleFlatMapOrWithError() {
 	//
 }
 
-func ExampleOption_OrElse() {
+func ExampleOption_Or() {
 	fallback := Some[string]("fallback")
 
 	some := Some[string]("actual")
-	fmt.Printf("%s\n", some.OrElse(fallback))
+	fmt.Printf("%s\n", some.Or(fallback))
 
 	none := None[string]()
-	fmt.Printf("%s\n", none.OrElse(fallback))
+	fmt.Printf("%s\n", none.Or(fallback))
 
 	// Output:
 	// Some[actual]

--- a/option.go
+++ b/option.go
@@ -102,9 +102,9 @@ func (o Option[T]) TakeOrElse(fallbackFunc func() T) T {
 	return o[value]
 }
 
-// OrElse returns the Option value according to the actual value existence.
+// Or returns the Option value according to the actual value existence.
 // If the receiver's Option value is Some, this function pass-through that to return. Otherwise, this value returns the `fallbackOptionValue`.
-func (o Option[T]) OrElse(fallbackOptionValue Option[T]) Option[T] {
+func (o Option[T]) Or(fallbackOptionValue Option[T]) Option[T] {
 	if o.IsNone() {
 		return fallbackOptionValue
 	}

--- a/option.go
+++ b/option.go
@@ -111,6 +111,15 @@ func (o Option[T]) Or(fallbackOptionValue Option[T]) Option[T] {
 	return o
 }
 
+// OrElse returns the Option value according to the actual value existence.
+// If the receiver's Option value is Some, this function pass-through that to return. Otherwise, this executes `fallbackOptionFunc` and returns the result value of that function.
+func (o Option[T]) OrElse(fallbackOptionFunc func() Option[T]) Option[T] {
+	if o.IsNone() {
+		return fallbackOptionFunc()
+	}
+	return o
+}
+
 // Filter returns self if the Option has a value and the value matches the condition of the predicate function.
 // In other cases (i.e. it doesn't match with the predicate or the Option is None), this returns None value.
 func (o Option[T]) Filter(predicate func(v T) bool) Option[T] {

--- a/option_test.go
+++ b/option_test.go
@@ -575,3 +575,10 @@ func TestOption_Or(t *testing.T) {
 	assert.EqualValues(t, Some[string]("actual").Or(fallback).Unwrap(), "actual")
 	assert.EqualValues(t, None[string]().Or(fallback).Unwrap(), "fallback")
 }
+
+func TestOption_OrElse(t *testing.T) {
+	fallbackFunc := func() Option[string] { return Some[string]("fallback") }
+
+	assert.EqualValues(t, Some[string]("actual").OrElse(fallbackFunc).Unwrap(), "actual")
+	assert.EqualValues(t, None[string]().OrElse(fallbackFunc).Unwrap(), "fallback")
+}

--- a/option_test.go
+++ b/option_test.go
@@ -569,9 +569,9 @@ func TestOption_String(t *testing.T) {
 	assert.Equal(t, "None[]", None[*MyStringer]().String())
 }
 
-func TestOption_OrElse(t *testing.T) {
+func TestOption_Or(t *testing.T) {
 	fallback := Some[string]("fallback")
 
-	assert.EqualValues(t, Some[string]("actual").OrElse(fallback).Unwrap(), "actual")
-	assert.EqualValues(t, None[string]().OrElse(fallback).Unwrap(), "fallback")
+	assert.EqualValues(t, Some[string]("actual").Or(fallback).Unwrap(), "actual")
+	assert.EqualValues(t, None[string]().Or(fallback).Unwrap(), "fallback")
 }


### PR DESCRIPTION
Rename `OrElse()` to `Or()` and add `OrElse()` (https://github.com/moznion/go-optional/issues/20#issuecomment-1341991992)

Fixes #21 