### PR TITLE
fix compilation error

### DIFF
--- a/convert_assign.go
+++ b/convert_assign.go
@@ -1,6 +1,7 @@
 package optional
 
 import (
+	_ "database/sql"
 	_ "unsafe"
 )
 


### PR DESCRIPTION
I encountered a problem during unit tests where the database/sql package was not imported. As a result, go:link did not find the database/sql.convertAssign definition during compilation, which led to a compilation error

Error when built tests:
![image](https://github.com/moznion/go-optional/assets/45568029/64c93ac8-507f-4aa3-8c0a-aebc8a9345b9)
