### PR TITLE
eliminate usage of go:linkname with convertAssign

### DIFF
--- a/convert_assign.go
+++ b/convert_assign.go
@@ -1,9 +1,0 @@
-package optional
-
-import (
-	_ "database/sql"
-	_ "unsafe"
-)
-
-//go:linkname sqlConvertAssign database/sql.convertAssign
-func sqlConvertAssign(dest, src any) error

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/moznion/go-optional
 
-go 1.21
+go 1.22
 
 require (
 	github.com/mattn/go-sqlite3 v1.14.22


### PR DESCRIPTION
This requires new API added in Go 1.22, but since 1.21 is already EOL, this should not be a problem in practice.

Ref: https://github.com/golang/go/issues/62146